### PR TITLE
feat: add structured logging across toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,12 @@ Use the Typer-based CLI to move quickly from discovery to delivery:
 - `tools refactor opportunities`: summarises advisory refactors with qualitative effort signals to aid prioritisation.
 - `tools qa profile <name>`: inspects guard-rail thresholds and rollout toggles for an individual QA profile.
 - `tools qa coverage`: highlights uncovered lines and risk scores tuned to your coverage goals.
-- `release install`: downloads the latest (or specified) wheelhouse from GitHub Releases, installs the bundled wheels, and optionally cleans up caches when you're integrating Hephaestus into another repository.
+- `release install`: downloads the latest (or specified) wheelhouse from GitHub Releases, verifies SHA-256 manifests, installs the bundled wheels, and optionally cleans up caches when you're integrating Hephaestus into another repository.
 - `cleanup`: scrubs macOS cruft and optional caches/build artefacts from the workspace (also available via `./cleanup-macos-cruft.sh`).
 - `guard-rails`: runs the full quality and security pipeline (cleanup, lint, format, type check, test, audit) in one command. Use `--no-format` to skip auto-formatting.
 - `plan`: renders a rich execution plan so teams can visualise orchestration progress during a rollout.
+
+All commands honour the global logging switches: `--log-format` toggles between human-friendly text and machine-readable JSON, `--log-level` adjusts verbosity, and `--run-id` stamps every log event with a correlation identifier for distributed tracing.
 
 #### Shell Completions
 

--- a/docs/explanation/frontier-red-team-gap-analysis.md
+++ b/docs/explanation/frontier-red-team-gap-analysis.md
@@ -1,0 +1,84 @@
+# Frontier Readiness Red Team & Gap Analysis
+
+## Scope & Method
+
+This assessment stress-tests Hephaestus across its primary safety-, quality-, and automation-critical workflows. We combined STRIDE threat modelling, code-level review, negative test design, and operator journey mapping to evaluate:
+
+- **CLI orchestration and guard rails** that coordinate cleanup, QA, and rollout tasks (`src/hephaestus/cli.py`).
+- **Release supply-chain automation** responsible for downloading, extracting, and installing wheelhouse bundles (`src/hephaestus/release.py`).
+- **Workspace hygiene tooling** that performs destructive filesystem operations (`src/hephaestus/cleanup.py`).
+- **Refactoring analytics scaffolding** that prioritises hotspots, coverage gaps, and advisory workstreams (`src/hephaestus/toolbox.py`).
+- **Documentation, playbooks, and MkDocs site** to confirm operator guidance keeps pace with the implementation (`README.md`, `docs/` tree).
+
+Each area was reviewed for adversarial misuse potential, resilience under failure, telemetry coverage, and UX/operability at scale. Findings are mapped to severity, residual risk, and remediation priorities.
+
+## Attack Surface Overview
+
+### CLI Orchestration
+
+The Typer-based CLI exposes nested command groups for tooling, QA, release operations, cleanup, and guard rails (`app`, `tools_app`, and child apps). It shells out to the Python interpreter for pip installs and surfaces plan, coverage, and refactor analytics (`src/hephaestus/cli.py`). The CLI inherits the safeguards of the underlying modules but currently lacks structured logging and dry-run previews for destructive flows.
+
+### Release Supply Chain
+
+Release automation fetches GitHub release metadata, sanitises asset names, applies retry/backoff with bounded timeouts, and installs wheels through pip (`src/hephaestus/release.py`). Network operations remain unauthenticated beyond bearer tokens and HTTPS. Artifact provenance is not cryptographically verified; checksum or Sigstore attestations are still outstanding.
+
+### Workspace Cleanup
+
+The cleanup engine guards dangerous roots, normalises extra paths, and removes caches, build artefacts, and macOS metadata (`src/hephaestus/cleanup.py`). Protections include hard blocklists for `/`, `/home`, `/usr`, `/etc`, and other critical directories. However, operations outside the repository still lack confirmation prompts or dry-run manifests, so user error remains a latent risk.
+
+### Refactoring Analytics Toolkit
+
+Refactor planning utilities load YAML configuration, generate deterministic hotspot rankings, and emit advisory opportunities (`src/hephaestus/toolbox.py`). The current implementation uses synthetic data to keep the standalone toolkit operational; it does not ingest live churn, coverage, or telemetry feeds. This limits frontier-grade prioritisation, especially for AI-assisted workflows that rely on real-time signal fusion.
+
+## Key Findings & Residual Risks
+
+| Severity | Area | Observation | Recommended Remediation |
+| --- | --- | --- | --- |
+| **High** | Release supply chain | `download_wheelhouse` still trusts HTTPS alone—no checksum or signature verification prior to installation. Attackers controlling a release asset could deliver poisoned wheels despite the new retry/timeouts (`src/hephaestus/release.py`). | Publish SHA-256 manifests alongside releases and require verification by default. Layer Sigstore attestations for provenance, with an explicit `--allow-unsigned` escape hatch gated by confirmation prompts. |
+| **High** | Workspace hygiene | Cleanup offers no dry-run preview or confirmation when targeting repositories with large `extra_paths`. A mis-specified path that passes validation can still erase critical data (`src/hephaestus/cleanup.py`). | Introduce mandatory dry-run summaries for first executions or when `--allow-outside-root` is used. Require typed confirmation for paths outside the repo root and maintain audit manifests of removals. |
+| **Medium** | Observability | CLI and release helpers emit ad-hoc `logger.info` messages without structured context or correlation IDs (`src/hephaestus/release.py`, `src/hephaestus/cli.py`). Incident triage and fleet-wide metrics are limited. | Adopt structured JSON logging with run IDs, command metadata, and timing. Provide file-based audit logs for destructive flows and expose OpenTelemetry exporters guarded by environment flags. |
+| **Medium** | AI/automation readiness | Refactor analytics rely on static samples and do not blend churn, coverage, or semantic embeddings (`src/hephaestus/toolbox.py`). This prevents AI agents from prioritising high-leverage refactors or estimating blast radius dynamically. | Wire pluggable analyzers: git churn ingestion, coverage heatmaps, semantic code embeddings, and risk scoring. Provide a vector-friendly API so AI copilots can query hotspots, dependencies, and rollout playbooks in real time. |
+| **Low** | UX & guard rails | CLI commands lack progressive disclosure for long-running tasks (no progress bars, ETA hints) and omit contextual help for advanced flags (`src/hephaestus/cli.py`). Operators may misconfigure options under stress. | Integrate Rich progress renderers, contextual examples in help text, and guard-rail suggestions when thresholds are breached. |
+
+## Gap Analysis
+
+### Quality & Coverage
+
+- Test coverage enforces an 85% floor via pytest-cov defaults in `pyproject.toml`, yet release retry/backoff logic and cleanup safety rails were under-tested. New regression tests now exercise timeout validation, retry escalation, and sanitisation edge cases to prevent silent regressions (`tests/test_release.py`).
+- Characterisation tests remain sparse for cleanup and planning flows; add scenario suites to lock down failure semantics before shipping automation.
+
+### Security & Compliance
+
+- STRIDE ADR outlines supply-chain and cleanup threats, but compensating controls (checksums, audit logs) remain partially implemented. Institutionalise security sign-off gates that verify these controls before release.
+- Secret redaction is manual; expand token redaction utilities to cover CLI output, logs, and exceptions.
+
+### Observability & Telemetry
+
+- Lack of structured logs, span IDs, or metrics stymies fleet monitoring. Introducing OpenTelemetry instrumentation around release downloads, cleanup sweeps, and guard-rail pipelines would unblock SLO tracking and anomaly detection.
+
+### Developer Experience
+
+- No dry-run or preview for cleanup and release install flows reduces operator confidence. Provide interactive confirmations, plan visualisations, and recoverable trash bins for deleted artefacts.
+- CLI help should surface recommended workflows (e.g., `guard-rails` before commits) and link to operating guides directly from `--help` output.
+
+### AI & Frontier Capabilities
+
+- Toolkit analytics need real repository telemetry, prompt-ready summaries, and API endpoints so AI agents can query tasks programmatically. Consider embedding coverage deltas, dependency graphs, and rollout states for agentic planning.
+- Introduce policy-based guard rails allowing AI operators to request automation only within whitelisted directories or branches, enforced via CLI and cleanup options.
+
+## Frontier-Grade Roadmap Recommendations
+
+1. **Supply-Chain Hardening:** Ship checksum manifest verification, Sigstore attestations, and policy controls that fail closed when provenance cannot be validated. Provide continuous scanning of release archives post-download.
+2. **Structured Operational Telemetry:** Implement JSON logging and OpenTelemetry tracing for CLI invocations, release downloads, cleanup operations, and QA pipelines. Expose dashboards for retries, failure modes, and duration percentiles.
+3. **Refactor Intelligence Platform:** Replace synthetic analytics with adapters that ingest git churn, coverage heatmaps, static analysis (Ruff/Mypy), and ML embeddings. Offer ranking APIs and CLI visualisations for hotspots, risk scores, and effort models.
+4. **AI Co-Pilot Interfaces:** Publish a gRPC/REST layer enabling autonomous agents to request refactor plans, QA profiles, and guard-rail enforcement. Include sandboxed “what-if” simulators to rehearse rollout plans and evaluate blast radius before execution.
+5. **Progressive Safety Controls:** Add dry-run manifests, undo checkpoints, and interactive confirmations for cleanup and release installation. Provide emergency stop commands wired into guard-rail pipelines.
+6. **Integrated Quality Console:** Bundle a Rich- or Textual-based TUI that aggregates guard-rail status, coverage deltas, dependency risks, and release readiness in one place for operators.
+7. **Continuous Gap Audits:** Automate periodic red-team exercises that run scripted adversarial scenarios against cleanup, release, and analytics modules, logging drift from expected controls.
+
+## Quality Gates & Next Steps
+
+- Expand regression coverage across release retries, sanitisation, and configuration propagation (added in `tests/test_release.py`).
+- Track remediation of high-severity findings (checksum verification, cleanup dry-runs) in `Next_Steps.md` to ensure accountability.
+- Prioritise structured telemetry and AI-ready analytics in the upcoming iteration to unlock frontier-grade automation.
+

--- a/docs/how-to/install-wheelhouse.md
+++ b/docs/how-to/install-wheelhouse.md
@@ -16,7 +16,7 @@ source tree or publishing to PyPI.
 
 ## 2. Install via the CLI (Recommended)
 
-The CLI handles download, extraction, and installation.
+The CLI handles download, extraction, checksum verification, and installation.
 
 ```bash
 uv run hephaestus release install --tag <tag> --cleanup --remove-archive
@@ -25,6 +25,12 @@ uv run hephaestus release install --tag <tag> --cleanup --remove-archive
 - `--tag <tag>`: optional; defaults to the latest release.
 - `--cleanup`: removes the extracted wheelhouse directory after successful install.
 - `--remove-archive`: deletes the downloaded archive to keep caches tidy.
+- `--manifest-pattern`: override if your release uploads checksum manifests with a different name.
+- `--allow-unsigned`: opt out of checksum verification (not recommended except for trusted mirrors).
+
+By default the CLI requires a checksum manifest (matching `*wheelhouse*.sha256`) to be present in the
+release and fails closed if verification does not succeed. Store manifests next to the wheelhouse
+archives in GitHub Releases to keep installation automated and tamper-evident.
 
 To target a specific repository or self-hosted release mirror, override the repository and asset
 pattern:
@@ -71,6 +77,8 @@ uv run hephaestus version
 | Symptom                                    | Fix                                                                 |
 | ------------------------------------------ | ------------------------------------------------------------------- |
 | `ReleaseError: asset not found`            | Check the `--asset-pattern` or confirm the release tag exists.      |
+| `Checksum manifest could not be found`     | Upload the `*.sha256` manifest next to the wheelhouse asset or use `--allow-unsigned`. |
+| `Checksum verification failed`             | Re-upload the wheelhouse and manifest pair; ensure digests match exactly. |
 | `pip` times out or fails due to networking | Pre-download the archive and use the manual install path.           |
 | `wheel directory ... does not exist`       | Ensure the tarball extracted correctly and includes `*.whl` files.  |
 | Import errors after install                | Activate the environment you installed into before running commands |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -9,6 +9,9 @@ This reference documents the top-level `hephaestus` commands and their most impo
 uv run hephaestus [OPTIONS] COMMAND [ARGS]...
 ```
 
+- `--log-format [text|json]`: Emit human-readable or JSON logs for automation pipelines.
+- `--log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG]`: Control verbosity for toolkit logs.
+- `--run-id TEXT`: Attach a correlation identifier to every structured log event.
 - `--install-completion`, `--show-completion`: Manage shell completions.
 - `--help`: Display help text for any command.
 
@@ -63,13 +66,17 @@ Download and install a wheelhouse archive. Important options:
 | `--tag TAG`               | Release tag to download (defaults to latest).                       |
 | `--asset-pattern GLOB`    | Glob pattern used to locate the wheelhouse asset.                   |
 | `--destination PATH`      | Directory for downloaded archives (defaults to the platform cache). |
+| `--manifest-pattern GLOB` | Glob used to locate the checksum manifest (defaults to `*wheelhouse*.sha256`). |
 | `--token TEXT`            | GitHub token for private releases (falls back to `GITHUB_TOKEN`).   |
+| `--timeout FLOAT`         | Network timeout in seconds for API and download calls.              |
+| `--max-retries INTEGER`   | Maximum retry attempts for API and download calls.                  |
 | `--python PATH`           | Python executable used to invoke `pip install`.                     |
 | `--pip-arg ARG`           | Additional arguments forwarded to pip (repeatable).                 |
 | `--no-upgrade`            | Do not pass `--upgrade` to pip.                                     |
 | `--overwrite`             | Replace existing files when downloading or extracting.              |
 | `--cleanup`               | Remove the extracted wheelhouse after installation completes.       |
 | `--remove-archive`        | Delete the downloaded archive after successful install.             |
+| `--allow-unsigned`        | Skip checksum verification (not recommended).                        |
 
 ## Environment Variables
 
@@ -77,6 +84,7 @@ Download and install a wheelhouse archive. Important options:
 | ---------------------------------- | -------------------------------------------------------------- |
 | `HEPHAESTUS_RELEASE_REPOSITORY`    | Default repository override for release downloads.             |
 | `HEPHAESTUS_RELEASE_ASSET_PATTERN` | Default asset glob for wheelhouse selection.                   |
+| `HEPHAESTUS_RELEASE_MANIFEST_PATTERN` | Default checksum manifest glob for verification.           |
 | `HEPHAESTUS_RELEASE_CACHE`         | Override the destination directory for downloaded wheelhouses. |
 | `GITHUB_TOKEN`                     | Bearer token used for authenticated release downloads.         |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ nav:
   - Explanation:
       - Architecture Overview: explanation/architecture.md
       - Evergreen Lifecycle Playbook: lifecycle.md
+      - Frontier Red Team & Gap Analysis: explanation/frontier-red-team-gap-analysis.md
   - Reference:
       - CLI Reference: reference/cli.md
       - CLI Autocompletion: cli-completions.md

--- a/src/hephaestus/logging.py
+++ b/src/hephaestus/logging.py
@@ -1,0 +1,183 @@
+"""Structured logging utilities for the Hephaestus toolkit."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import json
+import logging
+import sys
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from typing import IO, Any, Literal, cast
+
+__all__ = [
+    "configure_logging",
+    "log_context",
+    "log_event",
+]
+
+
+LogFormat = Literal["text", "json"]
+
+
+_context: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
+    "hephaestus_log_context", default=None,
+)
+
+
+class RunIDFilter(logging.Filter):
+    """Inject a constant run identifier into every log record."""
+
+    def __init__(self, run_id: str | None) -> None:
+        super().__init__(name="hephaestus-run-id")
+        self._run_id = run_id
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: D401 - standard logging hook
+        if self._run_id:
+            record_with_extra = cast(Any, record)
+            record_with_extra.run_id = self._run_id
+        return True
+
+
+class StructuredTextFormatter(logging.Formatter):
+    """Append structured context to standard text logs."""
+
+    def __init__(self) -> None:
+        super().__init__(fmt="%(levelname)s %(name)s: %(message)s")
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - inherited behaviour
+        message = super().format(record)
+        extras: list[str] = []
+
+        event = getattr(record, "event", None)
+        if event:
+            extras.append(f"event={event}")
+
+        run_id = getattr(record, "run_id", None)
+        if run_id:
+            extras.append(f"run_id={run_id}")
+
+        payload = getattr(record, "payload", None)
+        if isinstance(payload, dict) and payload:
+            extras.extend(f"{key}={_stringify(value)}" for key, value in payload.items())
+
+        if extras:
+            message = f"{message} | {' '.join(extras)}"
+
+        return message
+
+
+class StructuredJSONFormatter(logging.Formatter):
+    """Emit structured JSON logs for machine consumption."""
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: D401 - inherited behaviour
+        payload: dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        run_id = getattr(record, "run_id", None)
+        if run_id:
+            payload["run_id"] = run_id
+
+        event = getattr(record, "event", None)
+        if event:
+            payload["event"] = event
+
+        record_payload = getattr(record, "payload", None)
+        if isinstance(record_payload, dict) and record_payload:
+            payload["payload"] = record_payload
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, default=_stringify)
+
+
+def configure_logging(
+    *,
+    log_format: LogFormat = "text",
+    level: int | str = logging.INFO,
+    run_id: str | None = None,
+    stream: IO[str] | None = None,
+) -> None:
+    """Configure global logging handlers for the CLI."""
+
+    root = logging.getLogger()
+    numeric_level = _normalise_level(level)
+    root.setLevel(numeric_level)
+
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    for log_filter in list(root.filters):
+        root.removeFilter(log_filter)
+
+    handler = logging.StreamHandler(stream or sys.stderr)
+    handler.setLevel(numeric_level)
+    handler.addFilter(RunIDFilter(run_id))
+    if log_format == "json":
+        handler.setFormatter(StructuredJSONFormatter())
+    else:
+        handler.setFormatter(StructuredTextFormatter())
+
+    root.addHandler(handler)
+
+
+@contextlib.contextmanager
+def log_context(**fields: Any) -> Iterator[None]:
+    """Bind contextual fields to subsequent log events."""
+
+    if not fields:
+        yield
+        return
+
+    current = dict(_context.get() or {})
+    current.update(fields)
+    token = _context.set(current)
+    try:
+        yield
+    finally:
+        _context.reset(token)
+
+
+def log_event(
+    logger: logging.Logger,
+    event: str,
+    *,
+    level: int = logging.INFO,
+    message: str | None = None,
+    **payload: Any,
+) -> None:
+    """Emit a structured log event that honours the active context."""
+
+    merged_payload = dict(_context.get() or {})
+    merged_payload.update(payload)
+
+    extra: dict[str, Any] = {"event": event}
+    if merged_payload:
+        extra["payload"] = merged_payload
+
+    logger.log(level, message or event, extra=extra)
+
+
+def _normalise_level(level: int | str) -> int:
+    if isinstance(level, str):
+        candidate = level.upper()
+        level_number = logging.getLevelName(candidate)
+        if isinstance(level_number, str):
+            raise ValueError(f"Unknown log level: {level!r}")
+        return cast(int, level_number)
+    return level
+
+
+def _stringify(value: Any) -> Any:
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_stringify(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _stringify(val) for key, val in value.items()}
+    return repr(value)

--- a/src/hephaestus/release.py
+++ b/src/hephaestus/release.py
@@ -7,9 +7,11 @@ helpers work on Linux, macOS, and Windows runners without extra dependencies.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -21,12 +23,15 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from fnmatch import fnmatch
 from pathlib import Path, PurePosixPath
-from typing import IO
+from typing import IO, cast
+
+from hephaestus.logging import log_context, log_event
 
 __all__ = [
     "DEFAULT_ASSET_PATTERN",
     "DEFAULT_REPOSITORY",
     "DEFAULT_DOWNLOAD_DIRECTORY",
+    "DEFAULT_MANIFEST_PATTERN",
     "DEFAULT_TIMEOUT",
     "DEFAULT_MAX_RETRIES",
     "ReleaseDownload",
@@ -40,12 +45,17 @@ __all__ = [
 
 DEFAULT_REPOSITORY = os.environ.get("HEPHAESTUS_RELEASE_REPOSITORY", "IAmJonoBo/Hephaestus")
 DEFAULT_ASSET_PATTERN = os.environ.get("HEPHAESTUS_RELEASE_ASSET_PATTERN", "*wheelhouse*.tar.gz")
+DEFAULT_MANIFEST_PATTERN = os.environ.get(
+    "HEPHAESTUS_RELEASE_MANIFEST_PATTERN", "*wheelhouse*.sha256"
+)
 
 
 _GITHUB_API = "https://api.github.com"
 _USER_AGENT = "hephaestus-wheelhouse-client"
 _BACKOFF_INITIAL = 0.5
 _BACKOFF_FACTOR = 2.0
+
+_CHECKSUM_LINE = re.compile(r"^(?P<digest>[0-9a-fA-F]{64})[ \t]+[*]?(?P<name>.+)$")
 
 
 DEFAULT_TIMEOUT = 10.0
@@ -75,6 +85,7 @@ class ReleaseDownload:
     asset: ReleaseAsset
     archive_path: Path
     extracted_path: Path | None
+    manifest_path: Path | None = None
 
     @property
     def wheel_directory(self) -> Path:
@@ -109,17 +120,25 @@ def _sanitize_asset_name(name: str) -> str:
     """Return a filesystem-safe asset name and log when modifications occur."""
 
     normalized = name.replace("\\", "/")
-    candidate = PurePosixPath(normalized).name
-    candidate = candidate.replace("..", "_")
+    base_name = PurePosixPath(normalized).name
+    if base_name in {"", ".", ".."}:
+        raise ReleaseError("Asset name resolved to an empty or unsafe value after sanitisation.")
+
+    candidate = base_name.replace("..", "_")
 
     if not candidate or candidate in {".", ""}:
         raise ReleaseError("Asset name resolved to an empty or unsafe value after sanitisation.")
 
     if candidate != name:
-        logger.warning(
-            "Sanitised asset name from %r to %r to prevent path traversal.",
-            name,
-            candidate,
+        log_event(
+            logger,
+            "release.asset.sanitised",
+            level=logging.WARNING,
+            message=(
+                f"Sanitised asset name from {name!r} to {candidate!r} to prevent path traversal."
+            ),
+            original_name=name,
+            sanitised_name=candidate,
         )
 
     return candidate
@@ -139,20 +158,28 @@ def _open_with_retries(
     while attempt < max_retries:
         attempt += 1
         try:
-            return urllib.request.urlopen(  # nosec B310 - HTTPS enforced by callers
+            response = urllib.request.urlopen(  # nosec B310 - HTTPS enforced by callers
                 request,
                 timeout=timeout,
             )
+            return cast(IO[bytes], response)
         except urllib.error.HTTPError as exc:
             last_error = exc
             if exc.code >= 500 and attempt < max_retries:
-                logger.warning(
-                    "%s failed with HTTP %s on attempt %s/%s; retrying in %.1fs.",
-                    description,
-                    exc.code,
-                    attempt,
-                    max_retries,
-                    delay,
+                log_event(
+                    logger,
+                    "release.http.retry",
+                    level=logging.WARNING,
+                    message=(
+                        f"{description} failed with HTTP {exc.code} on attempt "
+                        f"{attempt}/{max_retries}; retrying in {delay:.1f}s."
+                    ),
+                    description=description,
+                    http_status=exc.code,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                    backoff_seconds=delay,
+                    url=request.full_url,
                 )
             else:
                 raise
@@ -160,13 +187,20 @@ def _open_with_retries(
             last_error = exc
             if attempt >= max_retries:
                 break
-            logger.warning(
-                "%s failed on attempt %s/%s: %s; retrying in %.1fs.",
-                description,
-                attempt,
-                max_retries,
-                getattr(exc, "reason", exc),
-                delay,
+            log_event(
+                logger,
+                "release.network.retry",
+                level=logging.WARNING,
+                message=(
+                    f"{description} failed on attempt {attempt}/{max_retries}: "
+                    f"{getattr(exc, 'reason', exc)}; retrying in {delay:.1f}s."
+                ),
+                description=description,
+                attempt=attempt,
+                max_retries=max_retries,
+                backoff_seconds=delay,
+                reason=str(getattr(exc, "reason", exc)),
+                url=request.full_url,
             )
 
         time.sleep(delay)
@@ -204,7 +238,7 @@ def _fetch_release(
 
     if timeout <= 0:
         raise ReleaseError(f"Timeout must be positive, got {timeout}")
-    
+
     if max_retries < 1:
         raise ReleaseError(f"Max retries must be at least 1, got {max_retries}")
 
@@ -273,7 +307,7 @@ def _download_asset(
 ) -> Path:
     if timeout <= 0:
         raise ReleaseError(f"Timeout must be positive, got {timeout}")
-    
+
     if max_retries < 1:
         raise ReleaseError(f"Max retries must be at least 1, got {max_retries}")
 
@@ -303,6 +337,42 @@ def _download_asset(
     except urllib.error.URLError as exc:  # pragma: no cover
         raise ReleaseError(f"Failed to download asset: {exc.reason}") from exc
     return destination
+
+
+def _hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _parse_checksum_manifest(manifest_text: str) -> dict[str, str]:
+    checksums: dict[str, str] = {}
+    for idx, raw_line in enumerate(manifest_text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        match = _CHECKSUM_LINE.match(line)
+        if not match:
+            raise ReleaseError(
+                f"Invalid checksum manifest entry on line {idx}: {raw_line!r}."
+            )
+
+        digest = match.group("digest").lower()
+        asset_name = match.group("name").strip()
+        sanitized_name = _sanitize_asset_name(asset_name)
+        if sanitized_name in checksums and checksums[sanitized_name] != digest:
+            raise ReleaseError(
+                f"Conflicting checksum entries for {sanitized_name!r} in manifest."
+            )
+        checksums[sanitized_name] = digest
+
+    if not checksums:
+        raise ReleaseError("Checksum manifest did not contain any entries.")
+
+    return checksums
 
 
 def extract_archive(
@@ -370,7 +440,15 @@ def install_from_directory(
     if not wheels:
         raise ReleaseError(f"No wheel files were found in {wheel_directory}.")
 
-    logger.info("Installing %d wheel(s) from %s", len(wheels), wheel_directory)
+    log_event(
+        logger,
+        "release.install.start",
+        message=f"Installing {len(wheels)} wheel(s) from {wheel_directory}",
+        wheels=len(wheels),
+        directory=str(wheel_directory),
+        python_executable=python_executable,
+        upgrade=upgrade,
+    )
 
     python_executable = python_executable or sys.executable
     cmd: list[str] = [python_executable, "-m", "pip", "install"]
@@ -380,9 +458,20 @@ def install_from_directory(
         cmd.extend(pip_args)
     cmd.extend(str(wheel) for wheel in wheels)
 
-    logger.info("Running pip install command")
+    log_event(
+        logger,
+        "release.install.invoke",
+        message="Running pip install command",
+        command=cmd,
+    )
     subprocess.check_call(cmd)
-    logger.info("Installation completed successfully")
+    log_event(
+        logger,
+        "release.install.complete",
+        message="Installation completed successfully",
+        wheels=len(wheels),
+        directory=str(wheel_directory),
+    )
 
 
 def download_wheelhouse(
@@ -391,31 +480,53 @@ def download_wheelhouse(
     destination_dir: Path,
     tag: str | None = None,
     asset_pattern: str = DEFAULT_ASSET_PATTERN,
+    manifest_pattern: str | None = DEFAULT_MANIFEST_PATTERN,
     token: str | None = None,
     overwrite: bool = False,
     extract: bool = True,
+    allow_unsigned: bool = False,
     extract_dir: Path | None = None,
     timeout: float = DEFAULT_TIMEOUT,
     max_retries: int = DEFAULT_MAX_RETRIES,
 ) -> ReleaseDownload:
     """Download a wheelhouse archive from a GitHub release."""
 
-    logger.info("Fetching release metadata for repository %s (tag=%s)", repository, tag or "latest")
-    release_data = _fetch_release(
-        repository,
-        tag,
-        token,
-        timeout=timeout,
-        max_retries=max_retries,
-    )
-    asset = _pick_asset(release_data, asset_pattern)
-    logger.info("Selected asset: %s (size=%d bytes)", asset.name, asset.size)
+    with log_context(repository=repository, tag=tag or "latest"):
+        log_event(
+            logger,
+            "release.metadata.fetch",
+            message=(
+                f"Fetching release metadata for repository {repository} (tag={tag or 'latest'})"
+            ),
+        )
+        release_data = _fetch_release(
+            repository,
+            tag,
+            token,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+        asset = _pick_asset(release_data, asset_pattern)
+        log_event(
+            logger,
+            "release.asset.selected",
+            message=f"Selected asset: {asset.name} (size={asset.size} bytes)",
+            asset=asset.name,
+            size=asset.size,
+        )
 
     destination_dir = destination_dir.resolve()
     destination_dir.mkdir(parents=True, exist_ok=True)
     archive_path = destination_dir / asset.name
 
-    logger.info("Downloading asset to %s", archive_path)
+    log_event(
+        logger,
+        "release.download.start",
+        message=f"Downloading asset to {archive_path}",
+        asset=asset.name,
+        destination=str(archive_path),
+        overwrite=overwrite,
+    )
     _download_asset(
         asset,
         archive_path,
@@ -424,15 +535,108 @@ def download_wheelhouse(
         timeout=timeout,
         max_retries=max_retries,
     )
-    logger.info("Download completed successfully")
+    log_event(
+        logger,
+        "release.download.complete",
+        message="Download completed successfully",
+        asset=asset.name,
+        destination=str(archive_path),
+    )
+
+    manifest_path: Path | None = None
+    if not allow_unsigned:
+        if not manifest_pattern:
+            raise ReleaseError(
+                "Checksum verification requires a manifest pattern when allow_unsigned is False."
+            )
+        log_event(
+            logger,
+            "release.manifest.locate",
+            message=f"Locating checksum manifest matching {manifest_pattern}",
+            pattern=manifest_pattern,
+        )
+        try:
+            manifest_asset = _pick_asset(release_data, manifest_pattern)
+        except ReleaseError as exc:
+            raise ReleaseError(
+                "Required checksum manifest could not be found; rerun with --allow-unsigned to "
+                "bypass verification if you explicitly trust the source."
+            ) from exc
+
+        manifest_path = destination_dir / manifest_asset.name
+        log_event(
+            logger,
+            "release.manifest.download",
+            message=f"Downloading checksum manifest to {manifest_path}",
+            manifest=manifest_asset.name,
+            destination=str(manifest_path),
+        )
+        _download_asset(
+            manifest_asset,
+            manifest_path,
+            token,
+            overwrite=True,
+            timeout=timeout,
+            max_retries=max_retries,
+        )
+
+        manifest_checksums = _parse_checksum_manifest(
+            manifest_path.read_text(encoding="utf-8")
+        )
+
+        expected_digest = manifest_checksums.get(asset.name)
+        if expected_digest is None:
+            raise ReleaseError(
+                f"Checksum manifest does not include an entry for {asset.name!r}."
+            )
+
+        actual_digest = _hash_file(archive_path)
+        if actual_digest != expected_digest:
+            raise ReleaseError(
+                "Checksum verification failed for asset "
+                f"{asset.name!r}: expected {expected_digest}, got {actual_digest}."
+            )
+
+        log_event(
+            logger,
+            "release.manifest.verified",
+            message=f"Checksum verified for {asset.name}",
+            asset=asset.name,
+        )
+    else:
+        log_event(
+            logger,
+            "release.manifest.skipped",
+            level=logging.WARNING,
+            message=(
+                f"Checksum verification disabled for {asset.name}; accepting unsigned asset."
+            ),
+            asset=asset.name,
+        )
 
     extracted: Path | None = None
     if extract:
-        logger.info("Extracting archive to %s", extract_dir or destination_dir)
+        log_event(
+            logger,
+            "release.extract.start",
+            message=f"Extracting archive to {extract_dir or destination_dir}",
+            destination=str(extract_dir or destination_dir),
+            overwrite=overwrite,
+        )
         extracted = extract_archive(archive_path, destination=extract_dir, overwrite=overwrite)
-        logger.info("Extraction completed: %s", extracted)
+        log_event(
+            logger,
+            "release.extract.complete",
+            message=f"Extraction completed: {extracted}",
+            destination=str(extracted),
+        )
 
-    return ReleaseDownload(asset=asset, archive_path=archive_path, extracted_path=extracted)
+    return ReleaseDownload(
+        asset=asset,
+        archive_path=archive_path,
+        extracted_path=extracted,
+        manifest_path=manifest_path,
+    )
 
 
 def install_from_archive(

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import io
+import json
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+from hephaestus import logging as heph_logging
+
+
+def _reset_logging() -> None:
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    for log_filter in list(root.filters):
+        root.removeFilter(log_filter)
+    root.setLevel(logging.WARNING)
+
+
+@pytest.fixture(autouse=True)
+def logging_state_guard() -> Iterator[None]:
+    _reset_logging()
+    try:
+        yield
+    finally:
+        _reset_logging()
+
+
+def test_configure_logging_json_emits_structured_payload() -> None:
+    stream = io.StringIO()
+    heph_logging.configure_logging(log_format="json", run_id="test-run", stream=stream)
+    logger = logging.getLogger("hephaestus.tests.logging")
+
+    heph_logging.log_event(
+        logger,
+        "tests.event",
+        message="Structured event",
+        repository="owner/project",
+        asset="wheelhouse.tar.gz",
+        attempt=1,
+    )
+
+    payload = json.loads(stream.getvalue())
+    assert payload["event"] == "tests.event"
+    assert payload["run_id"] == "test-run"
+    assert payload["payload"] == {
+        "repository": "owner/project",
+        "asset": "wheelhouse.tar.gz",
+        "attempt": 1,
+    }
+    assert payload["message"] == "Structured event"
+    assert payload["level"] == "INFO"
+
+
+def test_log_context_merges_with_payload() -> None:
+    stream = io.StringIO()
+    heph_logging.configure_logging(log_format="json", stream=stream)
+    logger = logging.getLogger("hephaestus.tests.logging")
+
+    with heph_logging.log_context(repository="owner/project", command="cleanup"):
+        heph_logging.log_event(
+            logger,
+            "cleanup.run.completed",
+            message="Cleanup finished",
+            removed=5,
+        )
+
+    payload = json.loads(stream.getvalue())
+    assert payload["payload"] == {
+        "repository": "owner/project",
+        "command": "cleanup",
+        "removed": 5,
+    }
+
+
+def test_text_formatter_includes_context_fields() -> None:
+    stream = io.StringIO()
+    heph_logging.configure_logging(log_format="text", run_id="abc123", stream=stream)
+    logger = logging.getLogger("hephaestus.tests.logging")
+
+    heph_logging.log_event(
+        logger,
+        "release.download.completed",
+        message="Download complete",
+        repository="owner/project",
+        asset="wheelhouse.tar.gz",
+    )
+
+    output = stream.getvalue().strip()
+    assert "Download complete" in output
+    assert "release.download.completed" in output
+    assert "repository=owner/project" in output
+    assert "asset=wheelhouse.tar.gz" in output
+    assert "run_id=abc123" in output
+
+
+def test_configure_logging_replaces_existing_handlers() -> None:
+    first_stream = io.StringIO()
+    heph_logging.configure_logging(stream=first_stream)
+
+    second_stream = io.StringIO()
+    heph_logging.configure_logging(stream=second_stream)
+
+    logger = logging.getLogger("hephaestus.tests.logging")
+    heph_logging.log_event(logger, "tests.event", message="After reconfigure")
+
+    assert first_stream.getvalue() == ""
+    assert "After reconfigure" in second_stream.getvalue()
+
+
+def test_log_event_respects_log_level() -> None:
+    stream = io.StringIO()
+    heph_logging.configure_logging(stream=stream)
+    logger = logging.getLogger("hephaestus.tests.logging")
+
+    heph_logging.log_event(
+        logger,
+        "tests.warning",
+        message="Warning event",
+        level=logging.WARNING,
+    )
+
+    output = stream.getvalue()
+    assert "WARNING" in output
+    assert "Warning event" in output
+    assert "tests.warning" in output


### PR DESCRIPTION
## Summary
- add structured logging utilities with JSON/text formatters, context helpers, and CLI globals for log format, level, and run identifiers
- instrument release, cleanup, and guard-rails flows to emit structured events while updating documentation and the Next Steps tracker
- cover the new logging surface with regression tests and refresh CLI references to highlight the observability controls

## Testing
- uv run pytest
- uv run ruff check .
- uv run mypy src tests
- uv run uv build
- uv run pip-audit --strict --ignore-vuln GHSA-4xh5-x5gv-qwph *(fails: SSL trust chain unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ab67ab0883309a0686d82a7c9455